### PR TITLE
Add Soap tracing in test mode

### DIFF
--- a/src/Message/LoginRequest.php
+++ b/src/Message/LoginRequest.php
@@ -118,7 +118,7 @@ class LoginRequest extends AbstractRequest
     public function sendData($data)
     {
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl());
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
         
         $response = call_user_func_array(array($this->soap, 'Login'), array($data));

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -236,7 +236,7 @@ class PurchaseRequest extends AbstractRequest
     public function sendData($data)
     {
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl());
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
         
         $response = call_user_func_array(array($this->soap, 'MakeCreditCardPayment'), array($data));

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -96,7 +96,7 @@ class RefundRequest extends AbstractRequest
     public function sendData($data)
     {
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl());
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
         
         $response = call_user_func_array(array($this->soap, 'RefundTransaction'), array($data));

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -96,4 +96,24 @@ class Response extends AbstractResponse
 
         return null;
     }
+
+    /**
+     * Soap Request
+     *
+     * @return string — The last SOAP request, as an XML string.
+     */
+    public function getSoapRequest()
+    {
+        return $this->request->soap->__getLastRequest();
+    }
+
+    /**
+     * Soap Response
+     *
+     * @return string — The last SOAP response, as an XML string.
+     */
+    public function getSoapResponse()
+    {
+        return $this->request->soap->__getLastResponse();
+    }
 }

--- a/src/Message/TransactionDetailsRequest.php
+++ b/src/Message/TransactionDetailsRequest.php
@@ -89,7 +89,7 @@ class TransactionDetailsRequest extends AbstractRequest
     public function sendData($data)
     {
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl());
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
         
         $response = call_user_func_array(array($this->soap, 'GetTransactionDetails'), array($data));

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -95,7 +95,7 @@ class VoidRequest extends AbstractRequest
     public function sendData($data)
     {
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl());
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
         
         $response = call_user_func_array(array($this->soap, 'VoidAPIPaymentRequest'), array($data));


### PR DESCRIPTION
Add methods to response class to get last soap request and response as XML string. This will be helpful for submitting bug reports to gateway providers.