### PR TITLE
Add getSoap method to aid in logging

### DIFF
--- a/src/Message/ChargeBankAccountRequest.php
+++ b/src/Message/ChargeBankAccountRequest.php
@@ -11,6 +11,11 @@ class ChargeBankAccountRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/ChargeCardRequest.php
+++ b/src/Message/ChargeCardRequest.php
@@ -11,6 +11,11 @@ class ChargeCardRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -11,6 +11,11 @@ class CreateBankAccountRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -12,6 +12,11 @@ class CreateCardRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/DeleteBankAccountRequest.php
+++ b/src/Message/DeleteBankAccountRequest.php
@@ -11,6 +11,11 @@ class DeleteBankAccountRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getSessionId()
     {
         return $this->getParameter('sessionId');

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -11,6 +11,11 @@ class DeleteCardRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getSessionId()
     {
         return $this->getParameter('sessionId');

--- a/src/Message/FinancialAccountsRequest.php
+++ b/src/Message/FinancialAccountsRequest.php
@@ -12,7 +12,12 @@ class FinancialAccountsRequest extends AbstractRequest
     /**
      * SoapClient Class
      */
-    public $soap = null;
+    private $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
 
     public function getSessionId()
     {

--- a/src/Message/LoginRequest.php
+++ b/src/Message/LoginRequest.php
@@ -12,7 +12,12 @@ class LoginRequest extends AbstractRequest
     /**
      * SoapClient Class
      */
-    public $soap = null;
+    private $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
 
     public function getPvLogin()
     {

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -12,6 +12,11 @@ class PurchaseRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -11,6 +11,11 @@ class PurchaseViaBankRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getPvLogin()
     {
         return $this->getParameter('pvLogin');

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -12,7 +12,12 @@ class RefundRequest extends AbstractRequest
     /**
      * SoapClient Class
      */
-    public $soap = null;
+    private $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
 
     public function getSessionId()
     {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -104,7 +104,7 @@ class Response extends AbstractResponse
      */
     public function getSoapRequest()
     {
-        return $this->request->soap->__getLastRequest();
+        return $this->request->getSoap()->__getLastRequest();
     }
 
     /**
@@ -114,6 +114,6 @@ class Response extends AbstractResponse
      */
     public function getSoapResponse()
     {
-        return $this->request->soap->__getLastResponse();
+        return $this->request->getSoap()->__getLastResponse();
     }
 }

--- a/src/Message/TransactionDetailsRequest.php
+++ b/src/Message/TransactionDetailsRequest.php
@@ -12,7 +12,12 @@ class TransactionDetailsRequest extends AbstractRequest
     /**
      * SoapClient Class
      */
-    public $soap = null;
+    private $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
 
     public function getSessionId()
     {

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -11,6 +11,11 @@ class UpdateBankAccountRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getSessionId()
     {
         return $this->getParameter('sessionId');

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -11,6 +11,11 @@ class UpdateCardRequest extends AbstractRequest
      */
     private $soap = null;
 
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+
     public function getSessionId()
     {
         return $this->getParameter('sessionId');

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -12,7 +12,12 @@ class VoidRequest extends AbstractRequest
     /**
      * SoapClient Class
      */
-    public $soap = null;
+    private $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
 
     public function getSessionId()
     {


### PR DESCRIPTION
This fixes the Response::getSoapResponse and getSoapRequest methods as the soap property on the request should remain private.

This does not impact production as the two methods are not yet being used.