### PR TITLE
Update response methods

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -82,6 +82,24 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Gateway Reference Id
+     *
+     * @return null|string A reference id provided by PaymentVision to represent an account
+     */
+    public function getReferenceId()
+    {
+        $referenceId = null;
+
+        array_walk_recursive($this->data, function ($val, $key) use (&$referenceId) {
+            if ($key == 'ReferenceID') {
+                $referenceId = $val;
+            }
+        });
+
+        return $referenceId;
+    }
+
+    /**
      * Session ID
      *
      * @return null|string A session id for authenticating multiple requests


### PR DESCRIPTION
This changes the name of the `getTransactionReference` method to `getTransactionId` and adds a new `getReferenceId` method.

Once this is released, a PR on Corvus will follow to utilize the new name.