### PR TITLE
Fix sessionID and referenceID case

### DIFF
--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -173,9 +173,9 @@ class UpdateBankAccountRequest extends AbstractRequest
 
         $data = array();
 
-        $data['sessionId'] = $this->getSessionId();
+        $data['sessionID'] = $this->getSessionId();
 
-        $data['referenceId'] = $this->getReferenceId();
+        $data['referenceID'] = $this->getReferenceId();
 
         $data['bankAccountUpdates'] = array(
 			'AccountType' => $this->getType(),


### PR DESCRIPTION
The `sessionID` and `referenceID` params had the wrong case.