### PR TITLE
Limit UserDefinedOne to 50 characters

### DIFF
--- a/src/Message/ChargeBankAccountRequest.php
+++ b/src/Message/ChargeBankAccountRequest.php
@@ -230,7 +230,7 @@ class ChargeBankAccountRequest extends AbstractRequest
         $data['achPayment'] = array(
             'Amount' => $this->getAmount(),
             'Comment' => $this->getComment(),
-            'UserDefinedOne' => $this->getUserDefinedOne(),
+            'UserDefinedOne' => substr($this->getUserDefinedOne(), 0, 50),
             'SecCode' => 'WEB',
             'MerchantPayeeCode' => $this->getMerchantPayeeCode(),
             'HoldForApproval' => $this->getHoldForApproval(),

--- a/src/Message/ChargeCardRequest.php
+++ b/src/Message/ChargeCardRequest.php
@@ -172,7 +172,7 @@ class ChargeCardRequest extends AbstractRequest
         $data['creditCardPayment'] = array(
             'Amount' => $this->getAmount(),
             'Comment' => $this->getComment(),
-            'UserDefinedOne' => $this->getUserDefinedOne(),
+            'UserDefinedOne' => substr($this->getUserDefinedOne(), 0, 50),
             'MerchantPayeeCode' => $this->getMerchantPayeeCode(),
             'HoldForApproval' => $this->getHoldForApproval(),
             'IsRecurring' => $this->getIsRecurring(),

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -161,7 +161,7 @@ class PurchaseRequest extends AbstractRequest
             'MerchantPayeeCode' => $this->getMerchantPayeeCode(),
             'Amount' => $this->getAmount(),
             'Comment' => $this->getComment(),
-            'UserDefinedOne' => $this->getUserDefinedOne(),
+            'UserDefinedOne' => substr($this->getUserDefinedOne(), 0, 50),
             'HoldForApproval' => $this->getHoldForApproval(),
             'IsRecurring' => $this->getIsRecurring(),
         );

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -299,7 +299,7 @@ class PurchaseViaBankRequest extends AbstractRequest
         $data['achPayment'] = array(
             'Amount' => $this->getAmount(),
             'Comment' => $this->getComment(),
-            'UserDefinedOne' => $this->getUserDefinedOne(),
+            'UserDefinedOne' => substr($this->getUserDefinedOne(), 0, 50),
             'SecCode' => 'WEB',
             'MerchantPayeeCode' => $this->getMerchantPayeeCode(),
             'HoldForApproval' => $this->getHoldForApproval(),


### PR DESCRIPTION
This fixes a PaymentVision Error: `UserDefinedOne must be less than or equal to 50 characters`.