### PR TITLE
Implement ReplaceCreditCardAccount

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -3,6 +3,22 @@
 namespace Omnipay\PaymentVision;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\PaymentVision\Message\ChargeBankAccountRequest;
+use Omnipay\PaymentVision\Message\ChargeCardRequest;
+use Omnipay\PaymentVision\Message\CreateBankAccountRequest;
+use Omnipay\PaymentVision\Message\CreateCardRequest;
+use Omnipay\PaymentVision\Message\DeleteBankAccountRequest;
+use Omnipay\PaymentVision\Message\DeleteCardRequest;
+use Omnipay\PaymentVision\Message\FinancialAccountsRequest;
+use Omnipay\PaymentVision\Message\LoginRequest;
+use Omnipay\PaymentVision\Message\PurchaseRequest;
+use Omnipay\PaymentVision\Message\PurchaseViaBankRequest;
+use Omnipay\PaymentVision\Message\RefundRequest;
+use Omnipay\PaymentVision\Message\TransactionDetailsRequest;
+use Omnipay\PaymentVision\Message\UpdateBankAccountRequest;
+use Omnipay\PaymentVision\Message\UpdateCardRequest;
+use Omnipay\PaymentVision\Message\UpdateCustomerRequest;
+use Omnipay\PaymentVision\Message\VoidRequest;
 
 /**
  * PaymentVision Gateway Class
@@ -43,7 +59,7 @@ class Gateway extends AbstractGateway
 
     public function login(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\LoginRequest', $parameters);
+        return $this->createRequest(LoginRequest::class, $parameters);
     }
 
     /***
@@ -52,7 +68,7 @@ class Gateway extends AbstractGateway
 
     public function purchaseViaBank(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\PurchaseViaBankRequest', $parameters);
+        return $this->createRequest(PurchaseViaBankRequest::class, $parameters);
     }
 
     /***
@@ -61,22 +77,22 @@ class Gateway extends AbstractGateway
 
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\PurchaseRequest', $parameters);
+        return $this->createRequest(PurchaseRequest::class, $parameters);
     }
 
     public function getTransactionDetails(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\TransactionDetailsRequest', $parameters);
+        return $this->createRequest(TransactionDetailsRequest::class, $parameters);
     }
 
     public function refund(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\RefundRequest', $parameters);
+        return $this->createRequest(RefundRequest::class, $parameters);
     }
 
     public function void(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\VoidRequest', $parameters);
+        return $this->createRequest(VoidRequest::class, $parameters);
     }
 
     /***
@@ -85,22 +101,22 @@ class Gateway extends AbstractGateway
 
     public function createBankAccount(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\CreateBankAccountRequest', $parameters);
+        return $this->createRequest(CreateBankAccountRequest::class, $parameters);
     }
 
     public function updateBankAccount(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\UpdateBankAccountRequest', $parameters);
+        return $this->createRequest(UpdateBankAccountRequest::class, $parameters);
     }
 
     public function deleteBankAccount(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\DeleteBankAccountRequest', $parameters);
+        return $this->createRequest(DeleteBankAccountRequest::class, $parameters);
     }
 
     public function chargeBankAccount(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\ChargeBankAccountRequest', $parameters);
+        return $this->createRequest(ChargeBankAccountRequest::class, $parameters);
     }
 
     /***
@@ -109,27 +125,27 @@ class Gateway extends AbstractGateway
 
     public function createCard(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\CreateCardRequest', $parameters);
+        return $this->createRequest(CreateCardRequest::class, $parameters);
     }
 
     public function updateCard(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\UpdateCardRequest', $parameters);
+        return $this->createRequest(UpdateCardRequest::class, $parameters);
     }
 
     public function deleteCard(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\DeleteCardRequest', $parameters);
+        return $this->createRequest(DeleteCardRequest::class, $parameters);
     }
 
     public function chargeCard(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\ChargeCardRequest', $parameters);
+        return $this->createRequest(ChargeCardRequest::class, $parameters);
     }
 
     public function financialAccounts(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\FinancialAccountsRequest', $parameters);
+        return $this->createRequest(FinancialAccountsRequest::class, $parameters);
     }
 
     /***
@@ -138,6 +154,6 @@ class Gateway extends AbstractGateway
 
     public function updateCustomer(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PaymentVision\Message\UpdateCustomerRequest', $parameters);
+        return $this->createRequest(UpdateCustomerRequest::class, $parameters);
     }
 }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -14,6 +14,7 @@ use Omnipay\PaymentVision\Message\LoginRequest;
 use Omnipay\PaymentVision\Message\PurchaseRequest;
 use Omnipay\PaymentVision\Message\PurchaseViaBankRequest;
 use Omnipay\PaymentVision\Message\RefundRequest;
+use Omnipay\PaymentVision\Message\ReplaceCardRequest;
 use Omnipay\PaymentVision\Message\TransactionDetailsRequest;
 use Omnipay\PaymentVision\Message\UpdateBankAccountRequest;
 use Omnipay\PaymentVision\Message\UpdateCardRequest;
@@ -131,6 +132,11 @@ class Gateway extends AbstractGateway
     public function updateCard(array $parameters = array())
     {
         return $this->createRequest(UpdateCardRequest::class, $parameters);
+    }
+
+    public function replaceCard(array $parameters = array())
+    {
+        return $this->createRequest(ReplaceCardRequest::class, $parameters);
     }
 
     public function deleteCard(array $parameters = array())

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Omnipay\PaymentVision\Message;
+
+use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
+use Omnipay\PaymentVision\CommonParametersTrait;
+
+abstract class AbstractRequest extends BaseAbstractRequest
+{
+    use CommonParametersTrait;
+
+    /**
+     * @var \SoapClient
+     */
+    protected $soap = null;
+
+    public function getSoap()
+    {
+        return $this->soap;
+    }
+}

--- a/src/Message/ChargeBankAccountRequest.php
+++ b/src/Message/ChargeBankAccountRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class ChargeBankAccountRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/ChargeCardRequest.php
+++ b/src/Message/ChargeCardRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class ChargeCardRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class CreateBankAccountRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -2,24 +2,10 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
 use Omnipay\PaymentVision\CreditCardHelper;
 
 class CreateCardRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/DeleteBankAccountRequest.php
+++ b/src/Message/DeleteBankAccountRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class DeleteBankAccountRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class DeleteCardRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/FinancialAccountsRequest.php
+++ b/src/Message/FinancialAccountsRequest.php
@@ -2,26 +2,11 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 /**
  * Send a request for details of a single transaction specified by transaction reference code
  */
 class FinancialAccountsRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/LoginRequest.php
+++ b/src/Message/LoginRequest.php
@@ -2,26 +2,11 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 /**
  * Log in to gateway and get a session id for certain requests
  */
 class LoginRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -2,24 +2,10 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
 use Omnipay\PaymentVision\CreditCardHelper;
 
 class PurchaseRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class PurchaseViaBankRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -2,26 +2,11 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 /**
  * Send a request for partially refunding a transaction
  */
 class RefundRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -117,7 +117,7 @@ class ReplaceCardRequest extends AbstractRequest
                 'TimeReceived' => date('n/j/Y g:i:s A'),
                 'CustomerReferenceCode' => 'CU' . $dateString,
                 'CreditCardAccountToken' => [
-                    'ReferenceID' => $data['referenceID'],
+                    'ReferenceID' => 'C' . $dateString,
                     'CreditCardAccount' => [
                         'CreditCardNumber' => 'XXXXXXXXXXXX' . substr($data['creditCardAccount']['CreditCardNumber'], -4, 4),
                         'CreditCardExpirationMonth' => $data['creditCardAccount']['CreditCardExpirationMonth'],

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -107,7 +107,7 @@ class ReplaceCardRequest extends AbstractRequest
     {
         $dateString = date('YmdHis');
         return (object) [
-            'UpdateCreditCardAccountResult' => [
+            'ReplaceCreditCardAccountResult' => [
                 'Responses' => [
                     'Response' => [
                         'ResponseCode' => '1000',

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Omnipay\PaymentVision\Message;
+
+use Omnipay\PaymentVision\CreditCardHelper;
+
+class ReplaceCardRequest extends AbstractRequest
+{
+    /**
+     * Get the raw data array for this message. The format of this varies from gateway to
+     * gateway, but will usually be either an associative array, or a SimpleXMLElement.
+     *
+     * @return mixed
+     */
+    public function getData()
+    {
+        $this->validate('sessionId', 'referenceId', 'card', 'nameOnCard', 'customerReferenceCode');
+        /** @var CreditCard $card */
+        $card = $this->getCard();
+        $card->validate();
+
+        $data = array();
+
+        $data['authentication'] = $this->getAuthenticationParams();
+
+        $data['sessionID'] = $this->getSessionId();
+
+        $data['referenceID'] = $this->getReferenceId();
+
+        // see if this needs to begin lowercase ("creditCardAccount") or not
+        $data['creditCardAccount'] = array(
+            'CreditCardNumber' => $card->getNumber(),
+            'CreditCardExpirationMonth' => CreditCardHelper::formatExpiryMonth($card->getExpiryMonth()),
+            'CreditCardExpirationYear' => $card->getExpiryYear(),
+            'CVVCode' => $card->getCvv(),
+            'CardType' => CreditCardHelper::paymentVisionCardType($card->getBrand()),
+            'BillingAddress' => array(
+                'NameOnCard' => $this->getNameOnCard(),
+                'AddressLineOne' => $card->getBillingAddress1(),
+                'City' => $card->getBillingCity(),
+                'State' => $card->getBillingState(),
+                'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
+                'Phone' => preg_replace("/[^0-9]/", '', $card->getBillingPhone()),
+            ),
+            'AccountUsePreferenceType' => 'MultiUse'
+        );
+
+        $data['customer'] = array(
+            'FirstName' => $card->getFirstName(),
+            'LastName' => $card->getLastName(),
+            'AdressLineOne' => $card->getBillingAddress1(),
+            'City' => $card->getBillingCity(),
+            'State' => $card->getBillingState(),
+            'Zip' => substr($card->getBillingPostcode(), 0, 5),
+            'CustomerReferenceCode' => $this->getCustomerReferenceCode(),
+        );
+
+        $data['merchantPayeeCode'] = $this->getMerchantPayeeCode();
+
+        return $data;
+    }
+
+    /**
+     * Get authentication strings
+     *
+     * @return array
+     */
+    private function getAuthenticationParams()
+    {
+        return array(
+            'PvLogin' => $this->getPvLogin(),
+            'PvPassword' => $this->getPvPassword(),
+            'PvAPIKey' => $this->getPvAPIKey(),
+            'PvToken' => $this->getPvToken(),
+        );
+    }
+
+    /**
+     * Send the request with specified data
+     *
+     * @param  mixed $data The data to send
+     * @return ResponseInterface
+     */
+    public function sendData($data)
+    {
+        if (true === $this->getStubMode()) {
+            $response = $this->getFakeResponse($data);
+            return $this->response = new FakeResponse($this, $response);
+        }
+
+        if (!$this->soap) {
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
+        }
+
+        $response = call_user_func_array(array($this->soap, 'ReplaceCreditCardAccount'), array($data));
+
+        return $this->response = new Response($this, $response);
+    }
+
+    /**
+     * Get fake response specific to this request
+     *
+     * @param  mixed $data The data that would otherwise be sent
+     * @return object
+     */
+    public function getFakeResponse($data)
+    {
+        $dateString = date('YmdHis');
+        return (object) [
+            'ReplaceCreditCardAccountResult' => [
+                'Responses' => [
+                    'Response' => [
+                        'ResponseCode' => '1000',
+                        'ErrorMessage' => '',
+                    ]
+                ],
+                'ReferenceID' => 'C' . $dateString,
+                'TimeReceived' => date('n/j/Y g:i:s A'),
+                'CustomerReferenceCode' => 'CU' . $dateString,
+                'CreditCard' => [
+                    'CreditCardNumber' => 'XXXXXXXXXXXX' . substr($data['creditCardAccount']['CreditCardNumber'], -4, 4),
+                    'CreditCardExpirationMonth' => $data['creditCardAccount']['CreditCardExpirationMonth'],
+                    'CreditCardExpirationYear' => $data['creditCardAccount']['CreditCardExpirationYear'],
+                    'CVVCode' => '',
+                    'CardType' => $data['creditCardAccount']['CardType'],
+                    'BillingAddress' => $data['creditCardAccount']['BillingAddress'],
+                    'FulfillmentGateway' => '',
+                    'AccountUsePreferenceType' => 'MultiUse',
+                    'CreditCardBinType' => 'Credit',
+                ]
+            ]
+        ];
+    }
+}

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -27,7 +27,7 @@ class ReplaceCardRequest extends AbstractRequest
 
         $data['referenceID'] = $this->getReferenceId();
 
-        // see if this needs to begin lowercase ("creditCardAccount") or not
+        // Does this need to begin lowercase ("creditCardAccount") or not?
         $data['creditCardAccount'] = array(
             'CreditCardNumber' => $card->getNumber(),
             'CreditCardExpirationMonth' => CreditCardHelper::formatExpiryMonth($card->getExpiryMonth()),
@@ -107,26 +107,32 @@ class ReplaceCardRequest extends AbstractRequest
     {
         $dateString = date('YmdHis');
         return (object) [
-            'ReplaceCreditCardAccountResult' => [
+            'UpdateCreditCardAccountResult' => [
                 'Responses' => [
                     'Response' => [
                         'ResponseCode' => '1000',
-                        'ErrorMessage' => '',
+                        'ErrorMessage' => ''
                     ]
                 ],
-                'ReferenceID' => 'C' . $dateString,
                 'TimeReceived' => date('n/j/Y g:i:s A'),
                 'CustomerReferenceCode' => 'CU' . $dateString,
-                'CreditCard' => [
-                    'CreditCardNumber' => 'XXXXXXXXXXXX' . substr($data['creditCardAccount']['CreditCardNumber'], -4, 4),
-                    'CreditCardExpirationMonth' => $data['creditCardAccount']['CreditCardExpirationMonth'],
-                    'CreditCardExpirationYear' => $data['creditCardAccount']['CreditCardExpirationYear'],
-                    'CVVCode' => '',
-                    'CardType' => $data['creditCardAccount']['CardType'],
-                    'BillingAddress' => $data['creditCardAccount']['BillingAddress'],
-                    'FulfillmentGateway' => '',
-                    'AccountUsePreferenceType' => 'MultiUse',
-                    'CreditCardBinType' => 'Credit',
+                'CreditCardAccountToken' => [
+                    'ReferenceID' => $data['referenceID'],
+                    'CreditCardAccount' => [
+                        'CreditCardNumber' => 'XXXXXXXXXXXX' . substr($data['creditCardAccount']['CreditCardNumber'], -4, 4),
+                        'CreditCardExpirationMonth' => $data['creditCardAccount']['CreditCardExpirationMonth'],
+                        'CreditCardExpirationYear' => $data['creditCardAccount']['CreditCardExpirationYear'],
+                        // 'CVVCode' => '',
+                        'CardType' => $data['creditCardAccount']['CardType'],
+                        'BillingAddress' => $data['creditCardAccount']['BillingAddress'],
+                        'FulfillmentGateway' => '',
+                        'AccountUsePreferenceType' => 'MultiUse',
+                        'CreditCardBinType' => 'Credit',
+                    ],
+                    'FinancialAccountStatusType' => 'Active',
+                    'LastUsed' => '0001-01-01T00:00:00',
+                    'LastUpdated' => '0001-01-01T00:00:00',
+                    'Created' => '0001-01-01T00:00:00'
                 ]
             ]
         ];

--- a/src/Message/TransactionDetailsRequest.php
+++ b/src/Message/TransactionDetailsRequest.php
@@ -2,26 +2,11 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 /**
  * Send a request for details of a single transaction specified by transaction reference code
  */
 class TransactionDetailsRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class UpdateBankAccountRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class UpdateCardRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -2,23 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 class UpdateCustomerRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -2,26 +2,11 @@
 
 namespace Omnipay\PaymentVision\Message;
 
-use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\PaymentVision\CommonParametersTrait;
-
 /**
  * Send a request for voiding a transaction
  */
 class VoidRequest extends AbstractRequest
 {
-    use CommonParametersTrait;
-
-    /**
-     * SoapClient Class
-     */
-    private $soap = null;
-
-    public function getSoap()
-    {
-        return $this->soap;
-    }
-
     /**
      * Get the raw data array for this message. The format of this varies from gateway to
      * gateway, but will usually be either an associative array, or a SimpleXMLElement.


### PR DESCRIPTION
This adds support for the ReplaceCreditCardAccount method of the PaymentVision API.

I have also made two other minor changes.
1. Some common code repeated in all the request classes has been moved into a new parent class `Omnipay\PaymentVision\Message\AbstractRequest`, which in turn extends the `Omnipay\Common\Message\AbstractRequest` class from the omnipay/common library.
2. In the `Omnipay\PaymentVision\Gateway` class, class name parameters have been changed from string-literal values (e.g. `'\Omnipay\PaymentVision\Message\LoginRequest'`) to class names plus `::class` (e.g. `LoginRequest::class`). This allows better IDE help during development.