### PR TITLE
Fix `getReferenceId` method with ReplaceCreditCardAccountResponse

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -34,10 +34,15 @@ abstract class AbstractRequest extends BaseAbstractRequest
         }
 
         if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
+            $this->soap = new \SoapClient($this->getWsdl(), [
+                'trace' => $this->getTestMode()
+            ]);
         }
 
-        $responseData = call_user_func_array(array($this->soap, $this->getRequestName()), array($data));
+        $responseData = call_user_func_array(
+            [$this->soap, $this->getRequestName()],
+            [$data]
+        );
 
         return $this->response = $this->makeResponse($responseData);
     }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PaymentVision\Message;
 
 use Omnipay\Common\Message\AbstractRequest as BaseAbstractRequest;
+use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\PaymentVision\CommonParametersTrait;
 
 abstract class AbstractRequest extends BaseAbstractRequest
@@ -18,4 +19,36 @@ abstract class AbstractRequest extends BaseAbstractRequest
     {
         return $this->soap;
     }
+
+    /**
+     * Send the request with specified data
+     *
+     * @param  mixed $data The data to send
+     * @return ResponseInterface
+     */
+    public function sendData($data) : ResponseInterface
+    {
+        if (true === $this->getStubMode()) {
+            $response = $this->getFakeResponse($data);
+            return $this->response = new FakeResponse($this, $response);
+        }
+
+        if (!$this->soap) {
+            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
+        }
+
+        $response = call_user_func_array(array($this->soap, $this->getRequestName()), array($data));
+
+        return $this->response = new Response($this, $response);
+    }
+
+    public abstract function getRequestName() : string;
+
+    /**
+     * Get fake response specific to this request
+     *
+     * @param  mixed $data The data that would otherwise be sent
+     * @return object
+     */
+    abstract public function getFakeResponse($data);
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -29,17 +29,17 @@ abstract class AbstractRequest extends BaseAbstractRequest
     public function sendData($data) : ResponseInterface
     {
         if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
+            $responseData = $this->getFakeResponse($data);
+            return $this->response = new FakeResponse($this, $responseData);
         }
 
         if (!$this->soap) {
             $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
         }
 
-        $response = call_user_func_array(array($this->soap, $this->getRequestName()), array($data));
+        $responseData = call_user_func_array(array($this->soap, $this->getRequestName()), array($data));
 
-        return $this->response = new Response($this, $response);
+        return $this->response = $this->makeResponse($responseData);
     }
 
     public abstract function getRequestName() : string;
@@ -51,4 +51,12 @@ abstract class AbstractRequest extends BaseAbstractRequest
      * @return object
      */
     abstract public function getFakeResponse($data);
+
+    /**
+     * @param mixed $data
+     */
+    protected function makeResponse($data) : ResponseInterface
+    {
+        return new Response($this, $data);
+    }
 }

--- a/src/Message/ChargeBankAccountRequest.php
+++ b/src/Message/ChargeBankAccountRequest.php
@@ -60,25 +60,9 @@ class ChargeBankAccountRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-        $response = call_user_func_array(array($this->soap, 'MakeIdBasedACHPayment'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'MakeIdBasedACHPayment';
     }
 
     /**

--- a/src/Message/ChargeCardRequest.php
+++ b/src/Message/ChargeCardRequest.php
@@ -61,26 +61,9 @@ class ChargeCardRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'MakeIdBasedCreditCardPayment'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'MakeIdBasedCreditCardPayment';
     }
 
     /**

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -66,26 +66,9 @@ class CreateBankAccountRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'AddBankAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'AddBankAccount';
     }
 
     /**

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -70,26 +70,9 @@ class CreateCardRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'AddCreditCardAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'AddCreditCardAccount';
     }
 
     /**

--- a/src/Message/DeleteBankAccountRequest.php
+++ b/src/Message/DeleteBankAccountRequest.php
@@ -25,28 +25,10 @@ class DeleteBankAccountRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'UnregisterBankAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'UnregisterBankAccount';
     }
-
 
     /**
      * Get fake response specific to this request

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -23,26 +23,9 @@ class DeleteCardRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'UnregisterCreditCardAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'UnregisterCreditCardAccount';
     }
 
     /**

--- a/src/Message/FinancialAccountsRequest.php
+++ b/src/Message/FinancialAccountsRequest.php
@@ -30,26 +30,9 @@ class FinancialAccountsRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'GetFinancialAccountTokens'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'GetFinancialAccountTokens';
     }
 
     /**

--- a/src/Message/LoginRequest.php
+++ b/src/Message/LoginRequest.php
@@ -37,26 +37,9 @@ class LoginRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'Login'), array($data));
-
-        return new Response($this, $response);
+        return 'Login';
     }
 
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -67,45 +67,6 @@ class PurchaseRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Initialize request with parameters
-     * @param array $parameters The parameters to send
-     */
-    // public function initialize(array $parameters = array())
-    // {
-
-    // }
-
-    /**
-     * Get all request parameters
-     *
-     * @return array
-     */
-    // public function getParameters()
-    // {
-
-    // }
-
-    /**
-     * Get the response to this request (if the request has been sent)
-     *
-     * @return ResponseInterface
-     */
-    // public function getResponse()
-    // {
-
-    // }
-
-    /**
-     * Send the request
-     *
-     * @return ResponseInterface
-     */
-    // public function send()
-    // {
-            // called in AbstractRequest
-    // }
-
     public function getRequestName() : string
     {
         return 'MakeCreditCardPayment';

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -106,26 +106,9 @@ class PurchaseRequest extends AbstractRequest
             // called in AbstractRequest
     // }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'MakeCreditCardPayment'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'MakeCreditCardPayment';
     }
 
     /**

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -89,25 +89,9 @@ class PurchaseViaBankRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-        $response = call_user_func_array(array($this->soap, 'MakeACHPayment'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'MakeACHPayment';
     }
 
     /**

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -25,26 +25,9 @@ class RefundRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'RefundTransaction'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'RefundTransaction';
     }
 
     /**

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -22,8 +22,6 @@ class ReplaceCardRequest extends AbstractRequest
 
         $data = array();
 
-        $data['authentication'] = $this->getAuthenticationParams();
-
         $data['sessionID'] = $this->getSessionId();
 
         $data['referenceID'] = $this->getReferenceId();
@@ -59,21 +57,6 @@ class ReplaceCardRequest extends AbstractRequest
         $data['merchantPayeeCode'] = $this->getMerchantPayeeCode();
 
         return $data;
-    }
-
-    /**
-     * Get authentication strings
-     *
-     * @return array
-     */
-    private function getAuthenticationParams()
-    {
-        return array(
-            'PvLogin' => $this->getPvLogin(),
-            'PvPassword' => $this->getPvPassword(),
-            'PvAPIKey' => $this->getPvAPIKey(),
-            'PvToken' => $this->getPvToken(),
-        );
     }
 
     public function getRequestName() : string

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -75,26 +75,9 @@ class ReplaceCardRequest extends AbstractRequest
         );
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'ReplaceCreditCardAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'ReplaceCreditCardAccount';
     }
 
     /**

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\PaymentVision\Message;
 
+use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\PaymentVision\CreditCardHelper;
 
 class ReplaceCardRequest extends AbstractRequest
@@ -119,5 +120,13 @@ class ReplaceCardRequest extends AbstractRequest
                 ]
             ]
         ];
+    }
+
+    /**
+     * @param mixed $data
+     */
+    protected function makeResponse($data) : ResponseInterface
+    {
+        return new ReplaceCardResponse($this, $data);
     }
 }

--- a/src/Message/ReplaceCardResponse.php
+++ b/src/Message/ReplaceCardResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Omnipay\PaymentVision\Message;
+
+use Omnipay\PaymentVision\Message\Response as MessageResponse;
+
+class ReplaceCardResponse extends MessageResponse
+{
+    /**
+     * Gateway Reference Id
+     *
+     * @return null|string A reference id provided by PaymentVision to represent an account
+     */
+    public function getReferenceId()
+    {
+        return $this->data['ReplaceCreditCardAccountResult']['CreditCardAccountToken']['ReferenceID'] ?? null;
+    }
+}

--- a/src/Message/TransactionDetailsRequest.php
+++ b/src/Message/TransactionDetailsRequest.php
@@ -28,26 +28,9 @@ class TransactionDetailsRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-        
-        $response = call_user_func_array(array($this->soap, 'GetTransactionDetails'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'GetTransactionDetails';
     }
 
     /**

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -47,26 +47,9 @@ class UpdateBankAccountRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'UpdateBankAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'UpdateBankAccount';
     }
 
     /**

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -46,26 +46,9 @@ class UpdateCardRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'UpdateCreditCardAccount'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'UpdateCreditCardAccount';
     }
 
     /**

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -33,26 +33,9 @@ class UpdateCustomerRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'UpdateCustomerInformation'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'UpdateCustomerInformation';
     }
 
     /**

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -24,26 +24,9 @@ class VoidRequest extends AbstractRequest
         return $data;
     }
 
-    /**
-     * Send the request with specified data
-     *
-     * @param  mixed $data The data to send
-     * @return ResponseInterface
-     */
-    public function sendData($data)
+    public function getRequestName() : string
     {
-        if (true === $this->getStubMode()) {
-            $response = $this->getFakeResponse($data);
-            return $this->response = new FakeResponse($this, $response);
-        }
-
-        if (!$this->soap) {
-            $this->soap = new \SoapClient($this->getWsdl(), array('trace' => $this->getTestMode()));
-        }
-
-        $response = call_user_func_array(array($this->soap, 'VoidAPIPaymentRequest'), array($data));
-
-        return $this->response = new Response($this, $response);
+        return 'VoidAPIPaymentRequest';
     }
 
     /**


### PR DESCRIPTION
The `Omnipay\PaymentVision\Message\Response::getReferenceId` method uses the `array_walk_recursive()` function (https://www.php.net/manual/en/function.array-walk-recursive.php) to find a "ReferenceID" key in the response data and returns that. The current implementation (below) would work fine if there is only a single "ReferenceID" key in the response data, but would be a problem if there were multiple "ReferenceID" keys.

![image](https://github.com/RTONational/omnipay-paymentvision/assets/20804591/fa4e1479-a9ec-467f-b820-c0a7dfaae7e4)

This problem occurs with the ReplaceCreditCardAccountResponse because the response contains a "TransactionDetails" object (second image, p. 152), which also contains a "ReferenceID" key. In the ReplaceCreditCardAccountResponse, the ReferenceID from the TransactionDetails will be the ReferenceID for the old credit card account (the one being replaced) but we want `getReferenceId` to return the ReferenceID for the new account. The `array_walk_recursive()` implementation will result in the last visited value being returned, so it returns the ReferenceID for the old account.

![image](https://github.com/RTONational/omnipay-paymentvision/assets/20804591/a7540b0c-8262-40a1-8f4f-8d44447af1c0)

---

![image](https://github.com/RTONational/omnipay-paymentvision/assets/20804591/bb44e0d4-5c0c-4fb7-a93f-94dd08585525)

To fix this I have created a customer Response subclass for the ReplaceCreditCardRequest, ReplaceCreditCardAccountResponse, with a more targeted implementation for `getReferenceId`. Other request classes could define their own custom response classes in the future.

As part of this change, the `sendData` methods from the various request classes, which were identical other than the Paymentvision request method, have been moved to the parent AbstractRequest class. A `getRequestName` gives the name of the request method for each request class.

In the ReplaceCreditCardAccount request, the "authentication" object has been removed from the request body. According to the PaymentVision, this request only needs a SessionID.