### PR TITLE
Fix deprecated null parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea/*
 /vendor/

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,7 +1,10 @@
 <?php
 
-if (!function_exists('stripDigits')) {
-    function stripDigits(?string $value): ?string
+namespace Omnipay\PaymentVision;
+
+class Helpers
+{
+    public static function stripDigits(?string $value): ?string
     {
         return null === $value
             ? null

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,7 +4,7 @@ namespace Omnipay\PaymentVision;
 
 class Helpers
 {
-    public static function stripDigits(?string $value): ?string
+    public static function stripNondigits(?string $value): ?string
     {
         return null === $value
             ? null

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -22,14 +22,14 @@ class CreateBankAccountRequest extends AbstractRequest
             'AccountType' => $this->getType(),
             'ABA' => $this->getRoutingNumber(),
             'AccountNumber' => $this->getAccountNumber(),
-            'BillingAddress' => array(
+            'BillingAddress' => array_filter([
                 'NameOnAccount' => $this->getNameOnAccount(),
                 'AddressLineOne' => $this->getBillingAddress1(),
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => preg_replace("/[^0-9]/", '', $this->getBillingPhone()),
-            ),
+                'Phone' => stripDigits($this->getBillingPhone()),
+            ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(
                 'CheckNumberPositionType' => 'RightOfAccount',

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -30,7 +30,7 @@ class CreateBankAccountRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($this->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(

--- a/src/Message/CreateBankAccountRequest.php
+++ b/src/Message/CreateBankAccountRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
+use Omnipay\PaymentVision\Helpers;
+
 class CreateBankAccountRequest extends AbstractRequest
 {
     /**
@@ -28,7 +30,7 @@ class CreateBankAccountRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\PaymentVision\Message;
 
 use Omnipay\PaymentVision\CreditCardHelper;
+use Omnipay\PaymentVision\Helpers;
 
 class CreateCardRequest extends AbstractRequest
 {

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -35,7 +35,7 @@ class CreateCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -36,7 +36,7 @@ class CreateCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($card->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -29,14 +29,14 @@ class CreateCardRequest extends AbstractRequest
             'CreditCardExpirationYear' => $card->getExpiryYear(),
             'CVVCode' => $card->getCvv(),
             'CardType' => CreditCardHelper::paymentVisionCardType($card->getBrand()),
-            'BillingAddress' => array(
+            'BillingAddress' => array_filter([
                 'NameOnCard' => $this->getNameOnCard(),
                 'AddressLineOne' => $card->getBillingAddress1(),
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => preg_replace("/[^0-9]/", '', $card->getBillingPhone()),
-            ),
+                'Phone' => stripDigits($card->getBillingPhone()),
+            ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );
 

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -30,24 +30,24 @@ class PurchaseViaBankRequest extends AbstractRequest
         $data['authentication'] = $this->getAuthenticationParams();
 
         $data['bankAccount'] = array(
-			'AccountType' => $this->getType(),
-			'ABA' => $this->getRoutingNumber(),
-			'AccountNumber' => $this->getAccountNumber(),
-			'BillingAddress' => array(
-				'NameOnAccount' => $this->getNameOnAccount(),
-				'AddressLineOne' => $this->getBillingAddress1(),
-				'City' => $this->getBillingCity(),
-				'State' => $this->getBillingState(),
-				'Zip' => substr($this->getBillingPostcode(), 0, 5),
-				'Phone' => preg_replace("/[^0-9]/", '', $this->getBillingPhone()),
-			),
+            'AccountType' => $this->getType(),
+            'ABA' => $this->getRoutingNumber(),
+            'AccountNumber' => $this->getAccountNumber(),
+            'BillingAddress' => array_filter([
+                'NameOnAccount' => $this->getNameOnAccount(),
+                'AddressLineOne' => $this->getBillingAddress1(),
+                'City' => $this->getBillingCity(),
+                'State' => $this->getBillingState(),
+                'Zip' => substr($this->getBillingPostcode(), 0, 5),
+                'Phone' => stripDigits($this->getBillingPhone()),
+            ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(
                 'CheckNumberPositionType' => 'RightOfAccount',
                 'CheckNumberAuxiliaryPositionType' => 'PrependToCheckNumber',
                 'CheckStockType' => 'Business',
             ),
-		);
+        );
 
         $data['achPayment'] = array(
             'Amount' => $this->getAmount(),
@@ -59,8 +59,8 @@ class PurchaseViaBankRequest extends AbstractRequest
             'IsRecurring' => $this->getIsRecurring(),
         );
         if ($settlementDate = $this->getSettlementDate()) {
-			$data['achPayment']['SettlementDate'] = date('m/d/Y', strtotime($settlementDate));
-		}
+            $data['achPayment']['SettlementDate'] = date('m/d/Y', strtotime($settlementDate));
+        }
 
         $data['customer'] = array(
             'FirstName' => $this->getFirstName(),

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -39,7 +39,7 @@ class PurchaseViaBankRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
+use Omnipay\PaymentVision\Helpers;
+
 class PurchaseViaBankRequest extends AbstractRequest
 {
     /**

--- a/src/Message/PurchaseViaBankRequest.php
+++ b/src/Message/PurchaseViaBankRequest.php
@@ -41,7 +41,7 @@ class PurchaseViaBankRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($this->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse',
             'CheckMICROption' => array(

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -33,14 +33,14 @@ class ReplaceCardRequest extends AbstractRequest
             'CreditCardExpirationYear' => $card->getExpiryYear(),
             'CVVCode' => $card->getCvv(),
             'CardType' => CreditCardHelper::paymentVisionCardType($card->getBrand()),
-            'BillingAddress' => array(
+            'BillingAddress' => array_filter([
                 'NameOnCard' => $this->getNameOnCard(),
                 'AddressLineOne' => $card->getBillingAddress1(),
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => preg_replace("/[^0-9]/", '', $card->getBillingPhone()),
-            ),
+                'Phone' => stripDigits($card->getBillingPhone()),
+            ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );
 

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -40,7 +40,7 @@ class ReplaceCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($card->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -4,6 +4,7 @@ namespace Omnipay\PaymentVision\Message;
 
 use Omnipay\Common\Message\ResponseInterface;
 use Omnipay\PaymentVision\CreditCardHelper;
+use Omnipay\PaymentVision\Helpers;
 
 class ReplaceCardRequest extends AbstractRequest
 {

--- a/src/Message/ReplaceCardRequest.php
+++ b/src/Message/ReplaceCardRequest.php
@@ -39,7 +39,7 @@ class ReplaceCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
             ]),
             'AccountUsePreferenceType' => 'MultiUse'
         );

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -22,15 +22,15 @@ class UpdateBankAccountRequest extends AbstractRequest
 
         $data['bankAccountUpdates'] = array(
             'AccountType' => $this->getType(),
-            'BillingAddress' => array(
+            'BillingAddress' => array_filter([
                 'NameOnAccount' => $this->getNameOnAccount(),
                 'AddressLineOne' => $this->getBillingAddress1(),
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => preg_replace("/[^0-9]/", '', $this->getBillingPhone()),
+                'Phone' => stripDigits($this->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode()
-            ),
+            ]),
             'Customer' => array(
                 'FirstName' => $this->getFirstName(),
                 'LastName' => $this->getLastName(),

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -30,7 +30,7 @@ class UpdateBankAccountRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($this->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode()
             ]),
             'Customer' => array(

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
+use Omnipay\PaymentVision\Helpers;
+
 class UpdateBankAccountRequest extends AbstractRequest
 {
     /**

--- a/src/Message/UpdateBankAccountRequest.php
+++ b/src/Message/UpdateBankAccountRequest.php
@@ -28,7 +28,7 @@ class UpdateBankAccountRequest extends AbstractRequest
                 'City' => $this->getBillingCity(),
                 'State' => $this->getBillingState(),
                 'Zip' => substr($this->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($this->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($this->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode()
             ]),
             'Customer' => array(

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -31,7 +31,7 @@ class UpdateCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripNondigits($card->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode(),
             ]),
             'Customer' => array(

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -29,7 +29,7 @@ class UpdateCardRequest extends AbstractRequest
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => stripDigits($card->getBillingPhone()),
+                'Phone' => Helpers::stripDigits($card->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode(),
             ]),
             'Customer' => array(

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\PaymentVision\Message;
 
+use Omnipay\PaymentVision\Helpers;
+
 class UpdateCardRequest extends AbstractRequest
 {
     /**

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -23,15 +23,15 @@ class UpdateCardRequest extends AbstractRequest
         $data['referenceID'] = $this->getReferenceId();
 
         $data['creditCardAccountUpdates'] = array(
-            'BillingAddress' => array(
+            'BillingAddress' => array_filter([
                 'NameOnCard' => $this->getNameOnCard(),
                 'AddressLineOne' => $card->getBillingAddress1(),
                 'City' => $card->getBillingCity(),
                 'State' => $card->getBillingState(),
                 'ZipCode' => substr($card->getBillingPostcode(), 0, 5),
-                'Phone' => preg_replace("/[^0-9]/", '', $card->getBillingPhone()),
+                'Phone' => stripDigits($card->getBillingPhone()),
                 'CustomerReferenceCode' => $this->getCustomerReferenceCode(),
-            ),
+            ]),
             'Customer' => array(
                 'FirstName' => $card->getFirstName(),
                 'LastName' => $card->getLastName(),

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,10 @@
+<?php
+
+if (!function_exists('stripDigits')) {
+    function stripDigits(?string $value): ?string
+    {
+        return null === $value
+            ? null
+            : preg_replace('/\D/', '', $value);
+    }
+}


### PR DESCRIPTION
Places passing nullable values to `preg_replace()` have been fixed to correctly handle null values, following the PHP 8.1+ rules.

>Passing null to non-nullable internal function parameters is deprecated.

https://www.php.net/releases/8.1/en.php#deprecations_and_bc_breaks

These BillingAddress objects are now filtered with `array_filter()` to remove null-valued fields.